### PR TITLE
Fix : validation error for msg 🚀 

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,13 +1,13 @@
 # Backend API
-PROJECT_NAME="FRDP"
+PROJECT_NAME=
+DOMAIN=
 
-# Generate secret key using openssl rand -hex 32
+# openssl rand -hex 32 - Generate secret key
 SECRET_KEY=
-
-# Email Defaut Intiger ex. 30, 60, 90
+USERS_OPEN_REGISTRATION=
 EMAIL_RESET_TOKEN_EXPIRE_HOURS=
 
-# Server Default
+# Server Settings
 SERVER_NAME=
 SERVER_HOST=
 
@@ -18,6 +18,6 @@ POSTGRES_DB=
 POSTGRES_PORT=
 POSTGRES_SERVER=
 
-PGADMIN_LISTEN_PORT=
+# PGADMIN_LISTEN_PORT=
 PGADMIN_DEFAULT_EMAIL=
 PGADMIN_DEFAULT_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
-
+.vscode/
 .idea/

--- a/api/endpoints/login.py
+++ b/api/endpoints/login.py
@@ -9,7 +9,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 
 import models
-from crud import crud_user
+import crud
 from crud.crud_user import CRUDUser
 from api import deps
 from core import security
@@ -90,7 +90,7 @@ def reset_password(
     email = verify_password_reset_token(token)
     if not email:
         raise HTTPException(status_code=400, detail="Invalid token")
-    user = crud_user.CRUDUser.get_by_email(db, email=email)
+    user = crud.user.get_by_email(db, email=email)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     hashed_password = get_password_hash(new_password)

--- a/api/endpoints/login.py
+++ b/api/endpoints/login.py
@@ -8,8 +8,8 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 
-import crud
 import models
+from crud import crud_user
 from crud.crud_user import CRUDUser
 from api import deps
 from core import security
@@ -60,19 +60,22 @@ def Check_Session(current_user: models.user.User = Depends(
     return current_user
 
 
-@router.post("/password-recovery/{email}", response_model=Msg)
+@router.post("/password-recovery/{email}",
+             response_model=Msg,
+             status_code=200,
+             response_description="Success")
 def recover_password(email: str, db: Session = Depends(deps.get_db)) -> Any:
     """
     Password Recovery
     """
     user = user1.get_by_email(db, email=email)
+
     if not user:
         raise HTTPException(
-            status_code=404,
+            status_code=422,
             detail="The user with this username does not exist in the system.",
         )
-    password_reset_token = generate_password_reset_token(email=email)
-    return {"Message": "Password recovery email sent"}
+    return {"msg": generate_password_reset_token(email=email)}
 
 
 @router.post("/reset-password/", response_model=Msg)
@@ -87,16 +90,11 @@ def reset_password(
     email = verify_password_reset_token(token)
     if not email:
         raise HTTPException(status_code=400, detail="Invalid token")
-    user = crud.user.get_by_email(db, email=email)
+    user = crud_user.CRUDUser.get_by_email(db, email=email)
     if not user:
-        raise HTTPException(
-            status_code=404,
-            detail="The user with this username does not exist in the system.",
-        )
-    elif not crud.user.is_active(user):
-        raise HTTPException(status_code=400, detail="Inactive user")
+        raise HTTPException(status_code=404, detail="User not found")
     hashed_password = get_password_hash(new_password)
     user.hashed_password = hashed_password
     db.add(user)
     db.commit()
-    return {"Message": "Password updated successfully"}
+    return {"msg": "Password updated successfully!"}

--- a/core/security.py
+++ b/core/security.py
@@ -17,9 +17,7 @@ def create_access_token(subject: Union[str, Any],
         expire = datetime.utcnow() + timedelta(
             minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode = {"exp": expire, "sub": str(subject)}
-    return jwt.encode(to_encode,
-                             settings.SECRET_KEY,
-                             algorithm=ALGORITHM)
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,7 @@ def generate_password_reset_token(email: str) -> str:
     now = datetime.utcnow()
     expires = now + delta
     exp = expires.timestamp()
-    encoded_jwt = jwt.encode(
+    return jwt.encode(
         {
             "exp": exp,
             "nbf": now,
@@ -18,14 +18,10 @@ def generate_password_reset_token(email: str) -> str:
         settings.SECRET_KEY,
         algorithm="HS256",
     )
-    return encoded_jwt
 
 
 def verify_password_reset_token(token: str) -> Optional[str]:
     try:
-        decoded_token = jwt.decode(token,
-                                   settings.SECRET_KEY,
-                                   algorithms=["HS256"])
-        return decoded_token["email"]
+        return jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
     except jwt.JWTError:
         return None


### PR DESCRIPTION
FastAPI will raise a ValidationError for the invalid response and set the field type. This can go wrong if the response model is not a pydantic model (or dataclass). When trying to produce the string representation of the exception, pydantic will try to produce the errors and fail because of the field type passed into the ValidationError not being a BaseModel or DataclassType. I am not sure if we need something like a ResponseValidationError to prevent this issue.

```sh
pydantic.error_wrappers.ValidationError: 1 validation error for Msg
response -> msg
  field required (type=value_error.missing)
```

- Schema.py 
```py
class Msg(BaseModel):
    msg: int
```

- Login.py
```py
@router.post("/password-recovery/{email}", response_model=Msg)
def recover_password(email: str, db: Session = Depends(deps.get_db)) -> Any:
    """
    Password Recovery
    """
    user = user1.get_by_email(db, email=email)
    if not user:
        raise HTTPException(
            status_code=404,
            detail="The user with this username does not exist in the system.",
        )
    password_reset_token = generate_password_reset_token(email=email)
    return {"Message": "Password recovery email sent"}
```

- This is some reference Close to the same issue 
https://github.com/tiangolo/fastapi/issues/1275
https://github.com/tiangolo/fastapi/issues/478